### PR TITLE
Prevent pipeline workflow in forks

### DIFF
--- a/.github/workflows/pipeline-workflow.yml
+++ b/.github/workflows/pipeline-workflow.yml
@@ -8,6 +8,7 @@ on: push
 jobs:
   pipeline-job:
     name: Pipeline Job
+    if: github.repository_owner == 'aws-solutions'
     runs-on: ubuntu-latest
     permissions:
       id-token: write


### PR DESCRIPTION
The pipeline workflow fails in forks because AWS credentials are not present. This alters the steps to only run the workflow in the `aws-solutions`-owned repository.